### PR TITLE
Getting rid of Array filterOut.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 lib-cov
 *.seed
 *.log

--- a/lib/array.js
+++ b/lib/array.js
@@ -67,40 +67,6 @@ function testRemove(callback)
 	testing.success(callback);
 }
 
-/**
- * Return a new array with only those elements that do not match the checker. Params:
- *	- checker: a function that checks all elements, and only lets through
- *	those for which the checker does _not_ return true.
- */
-newArray.filterOut = function(checker)
-{
-	var result = [];
-	this.forEach(function(element)
-	{
-		if (!checker(element))
-		{
-			result.push(element);
-		}
-	});
-	return result;
-};
-
-function testFilterOut(callback)
-{
-	var array = ['a', 'b', 'c', 'd1', 'd2'];
-	var stringified = JSON.stringify(array);
-	var removed = array.filterOut(function(element)
-	{
-		return element.startsWith('d');
-	});
-	testing.assertEquals(array.length, 5, 'Original array shortened', callback);
-	testing.assertEquals(JSON.stringify(array), stringified, 'Original array modified', callback);
-	testing.assertEquals(removed.length, 3, 'Elements not removed', callback);
-	testing.assert(!removed.contains('d1'), 'Wrong first element not filtered', callback);
-	testing.assert(!removed.contains('d2'), 'Wrong second element not filtered', callback);
-	testing.success(callback);
-}
-
 // add new object functions as properties
 core.addProperties(Object.prototype, newArray);
 
@@ -112,7 +78,6 @@ exports.test = function(callback)
 	var tests = [
 		testContains,
 		testRemove,
-		testFilterOut,
 	];
 	testing.run(tests, callback);
 };

--- a/lib/object.js
+++ b/lib/object.js
@@ -194,20 +194,18 @@ function testForEach(callback)
  */
 newObject.filterIn = function(callback)
 {
-	if (this.isArray())
-	{
+	if (this.isArray()) {
 		return this.filter(callback);
-	}
-	var result = {};
-	for (var key in this)
-	{
-		var value = this[key];
-		if (callback(value))
-		{
-			result[key] = value;
+	} else {
+		var result = {};
+		for (var key in this) {
+			var value = this[key];
+			if (callback(value)) {
+				result[key] = value;
+			}
 		}
+		return result;
 	}
-	return result;
 };
 
 /**
@@ -228,6 +226,7 @@ function testFilter(callback)
 		b: 2,
 		c: 3,
 	};
+
 	var filtered = object.filterIn(function(value)
 	{
 		return value < 3;
@@ -235,12 +234,14 @@ function testFilter(callback)
 	testing.assertEquals(filtered.countProperties(), 2, 'Invalid <3 count', callback);
 	testing.assertEquals(filtered.a, 1, 'Invalid a in filtered', callback);
 	testing.assertEquals(filtered.b, 2, 'Invalid b in filtered', callback);
+
 	filtered = object.filterIn(function(value)
 	{
 		return value > 2;
 	});
 	testing.assertEquals(filtered.countProperties(), 1, 'Invalid >3 count', callback);
 	testing.assertEquals(filtered.c, 3, 'Invalid c in filtered', callback);
+
 	filtered = object.filterOut(function(value)
 	{
 		return value > 2;

--- a/test.js
+++ b/test.js
@@ -36,7 +36,7 @@ exports.test = function(callback)
 	var tests = {
 		cleanObjects: testCleanObjects,
 	};
-	var libs = [ 'core', 'string', 'math', 'object' ];
+	var libs = [ 'core', 'string', 'array', 'math', 'object' ];
 	libs.forEach(function(lib)
 	{
 		tests[lib] = require('./lib/' + lib + '.js').test;


### PR DESCRIPTION
As an `array` is an `object` in JS, calling `filterOut` on an object invokes the array's method. Also, `filterOut` for an array seems redundant as `filter` already exists. This should fix the errors in PR #2.

Also ignoring `.DS_Store` for OS X users.
