### PR TITLE
Object.prototype.renameProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,16 @@ Example:
 //=> {a: 1}
 ```
 
+### object.renameProperties(mappingObject)
+
+Rename an object's properties based on another 'mapping' object's key/value pairs.
+Example:
+
+```js
+{a: 1, b: 2}.renameProperties({a: 'z', b: 'y'});
+//=> {z: 1, y: 2}
+```
+
 ## Object Functions
 
 Functions added to `Object` are available to operate on parameter objects.

--- a/lib/object.js
+++ b/lib/object.js
@@ -132,7 +132,7 @@ newObject.filterOut = function(callback)
  * is renamed to the value corresponding to the property from the mapping object.
  * Example:
  * var bla = {'yo': 'hi', 'bo': 'hi'};
- * bla.mapProperties({'bo': 'do'});
+ * bla.renameProperties({'bo': 'do'});
  * THEN 
  * bla.hasOwnProperty('do') === true
  * bla.do === 'hi'

--- a/lib/object.js
+++ b/lib/object.js
@@ -128,6 +128,27 @@ newObject.filterOut = function(callback)
 };
 
 /**
+ * For each property in the mapping object, if 'this' has a property of the same name, then the name of the property in 'this'
+ * is renamed to the value corresponding to the property from the mapping object.
+ * Example:
+ * var bla = {'yo': 'hi', 'bo': 'hi'};
+ * bla.mapProperties({'bo': 'do'});
+ * THEN 
+ * bla.hasOwnProperty('do') === true
+ * bla.do === 'hi'
+ */
+newObject.renameProperties = function(mappingObject)
+{
+	var self = this;
+	mappingObject.forEach(function(newPropertyName, oldPropertyName) {
+	    if (self.hasOwnProperty(oldPropertyName)) {
+	    	self[newPropertyName] = self[oldPropertyName];
+	        delete self[oldPropertyName];
+	    }
+	});
+}
+
+/**
  * Get all values for a parameter object in an array.
  * Note: operates on the global Object, not on the prototype.
  */

--- a/lib/object.js
+++ b/lib/object.js
@@ -140,6 +140,7 @@ newObject.filterOut = function(callback)
 newObject.renameProperties = function(mappingObject)
 {
 	var self = this;
+	
 	newObject.forEach.call(mappingObject, function(newPropertyName, oldPropertyName)
 	{
 	    if (self.hasOwnProperty(oldPropertyName)) 
@@ -148,6 +149,8 @@ newObject.renameProperties = function(mappingObject)
 	        delete self[oldPropertyName];
 	    }
 	});
+
+	return self;
 }
 
 /**

--- a/lib/object.js
+++ b/lib/object.js
@@ -140,8 +140,10 @@ newObject.filterOut = function(callback)
 newObject.renameProperties = function(mappingObject)
 {
 	var self = this;
-	mappingObject.forEach(function(newPropertyName, oldPropertyName) {
-	    if (self.hasOwnProperty(oldPropertyName)) {
+	newObject.forEach.call(mappingObject, function(newPropertyName, oldPropertyName)
+	{
+	    if (self.hasOwnProperty(oldPropertyName)) 
+	    {
 	    	self[newPropertyName] = self[oldPropertyName];
 	        delete self[oldPropertyName];
 	    }

--- a/test/object.js
+++ b/test/object.js
@@ -148,6 +148,37 @@ function testValues(callback)
 	testing.success(callback);
 }
 
+function testRenameProperties(callback)
+{
+	var abcObj = {};
+
+	var object = {
+		first: 'a',
+		second: 'b',
+		1: 37,
+		'a-b.c': abcObj,
+		'control': 'Not Renamed'
+	};
+
+	var newNames = {first: 'mapFirst', second: 2, 1: 'One', 'a-b.c': 'abc'};
+	object.renameProperties(newNames);
+
+	// Test that all properties (except the control property) have been mapped away.
+	testing.assertEquals(object.hasOwnProperty('first'), false, callback);
+	testing.assertEquals(object.hasOwnProperty('second'), false, callback);
+	testing.assertEquals(object.hasOwnProperty(1), false, callback);
+	testing.assertEquals(object.hasOwnProperty('a-b.c'), false, callback);
+	testing.assertEquals(object.control, 'Not Renamed', callback);
+
+	// Test that the newly mapped properties are present and correct.
+	testing.assertEquals(object.mapFirst, 'a', callback);
+	testing.assertEquals(object[2], 'b', callback);
+	testing.assertEquals(object.One, 37, callback);
+	testing.assertEquals(object.abc, abcObj, callback);
+
+	testing.success(callback);
+}
+
 /**
  * Run package tests.
  */
@@ -160,6 +191,7 @@ exports.test = function(callback)
 		testFilter,
 		testForEach,
 		testValues,
+		testRenameProperties,
 	];
 	testing.run(tests, callback);
 };


### PR DESCRIPTION
Provides a method for bulk rename of an object's properties based on another 'mapping' object's key/value pairs.

Example:
```javascript
var bla = {'yo': 'hi', 'bo': 'hi'};
bla.renameProperties({'bo': 'do'});
```
then the following statements are true
```javascript
bla.hasOwnProperty('do') === true
bla.hasOwnProperty('bo') === false
bla.do === 'hi'
```